### PR TITLE
Adjusted image height and help component height on smaller devices

### DIFF
--- a/src/lib/components/CoverContainer.svelte
+++ b/src/lib/components/CoverContainer.svelte
@@ -112,10 +112,4 @@
       padding: 0.75rem;
     }
   }
-
-  @media only screen and (max-height: 37.5rem) {
-    .cover-container {
-      width: min(40rem, 95vw);
-    }
-  }
 </style>

--- a/src/lib/components/Help.svelte
+++ b/src/lib/components/Help.svelte
@@ -116,4 +116,15 @@
       font-size: 0.75rem;
     }
   }
+
+  @media only screen and (max-height: 37.5rem) {
+    .wordle-tiles {
+      width: 2rem;
+      font-size: 1rem;
+    }
+
+    p {
+      margin-block: 0.5rem;
+    }
+  }
 </style>

--- a/src/lib/components/WordCard.svelte
+++ b/src/lib/components/WordCard.svelte
@@ -28,6 +28,7 @@
   .supplemental-image {
     margin-block-start: 1rem;
     max-width: 80%;
+    max-height: 12rem;
     object-fit: cotain;
   }
 </style>


### PR DESCRIPTION
In this PR, I was able to:
- Limit image sizes to a certain max-height
- Compressing the help component in smaller VH.

Fixed issues with heights in general.
![Screenshot (188)](https://github.com/tomasohCHOM/Devdle/assets/112128328/7af960e3-eb5e-4549-b36d-8c4586e8748b)
![Screenshot (189)](https://github.com/tomasohCHOM/Devdle/assets/112128328/f9af2562-b786-411b-8cab-1baf5f7fb288)
