### PR TITLE
Disabled double tap at top element

### DIFF
--- a/src/lib/components/Board.svelte
+++ b/src/lib/components/Board.svelte
@@ -25,31 +25,29 @@
   };
 </script>
 
-<main>
-  <section class="board">
-    {#each NUM_ROWS as _, i}
-      <div class="board-row">
-        {#each NUM_CELLS as _, j}
-          <div
-            class="board-cell {guesses[i] !== undefined
-              ? convertColorsToCSSColorClasses(i, j)
-              : ''}"
-            class:border-active={i === guesses.length &&
-              currentGuess[j] !== undefined}
-            class:shake={i === guesses.length && isError === true}
-            style="--order: {j}; --win-delay: {WORD_REVEAL_ANIMATION_DELAY};"
-          >
-            {#if i === numAttempts && currentGuess.length - 1 >= j}
-              {currentGuess[j].toUpperCase()}
-            {:else}
-              {guesses[i]?.[j].toUpperCase() ?? ""}
-            {/if}
-          </div>
-        {/each}
-      </div>
-    {/each}
-  </section>
-</main>
+<section class="board">
+  {#each NUM_ROWS as _, i}
+    <div class="board-row">
+      {#each NUM_CELLS as _, j}
+        <div
+          class="board-cell {guesses[i] !== undefined
+            ? convertColorsToCSSColorClasses(i, j)
+            : ''}"
+          class:border-active={i === guesses.length &&
+            currentGuess[j] !== undefined}
+          class:shake={i === guesses.length && isError === true}
+          style="--order: {j}; --win-delay: {WORD_REVEAL_ANIMATION_DELAY};"
+        >
+          {#if i === numAttempts && currentGuess.length - 1 >= j}
+            {currentGuess[j].toUpperCase()}
+          {:else}
+            {guesses[i]?.[j].toUpperCase() ?? ""}
+          {/if}
+        </div>
+      {/each}
+    </div>
+  {/each}
+</section>
 
 <style lang="scss">
   .board-row {

--- a/src/lib/components/KeyBoard.svelte
+++ b/src/lib/components/KeyBoard.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { WORD_REVEAL_ANIMATION_DELAY } from "$lib/constants/values";
+  // import { WORD_REVEAL_ANIMATION_DELAY } from "$lib/constants/values";
 
   export let currentGuess: string;
   export let guesses: string[];
@@ -47,7 +47,7 @@
   };
 </script>
 
-<main>
+<section class="disable-double-tap-zoom">
   <br />
   {#key guesses}
     {#each keys as key}
@@ -72,10 +72,10 @@
       </div>
     {/each}
   {/key}
-</main>
+</section>
 
 <style>
-  main {
+  section {
     padding-block-end: 1.5rem;
   }
 
@@ -107,6 +107,11 @@
     color: var(--color-true-white);
     /* animation-name: keyboardDelay;
     animation-delay: calc(var(--key-delay) * 1ms); */
+  }
+
+  /* For disabling constant double tapping on mobile devices. */
+  .disable-double-tap-zoom {
+    touch-action: manipulation;
   }
 
   @keyframes keyboardDelay {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -113,10 +113,6 @@ html[data-theme="dark"] {
   -webkit-filter: brightness(0) invert(1);
 }
 
-.disable-double-tap-zoom {
-  touch-action: none;
-}
-
 @media screen and (max-width: 30em) {
   .icon-images {
     width: 1.5rem;


### PR DESCRIPTION
Fixed #2 by adding CSS property `touch-action: manipulation` to the section element of the Keyboard component. This disables double tapping when an user is on mobile (can result in annoying behavior when the user quickly taps on keyboard letters).